### PR TITLE
Feat: add new quests endpoints

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -11,7 +11,7 @@ macro_rules! pub_struct {
         }
     }
 }
-
+#[rustfmt::skip]
 pub_struct!(Server { port: u16, });
 
 pub_struct!(Database {
@@ -29,7 +29,11 @@ pub_struct!(Variables {
     is_testnet: bool,
 });
 
-pub_struct!(NamingContract { address: String, });
+pub_struct!(StarknetIdContracts {
+    naming_contract: String,
+    verifier_contract: String,
+    identity_contract: String,
+});
 
 pub_struct!(Quests {
     starkfighter_server: String,
@@ -40,7 +44,7 @@ pub_struct!(Config {
     database: Database,
     nft_contract: NftContract,
     variables: Variables,
-    naming_contract: NamingContract,
+    starknetid_contracts: StarknetIdContracts,
     quests: Quests,
 });
 

--- a/src/endpoints/quests/starknetid/mod.rs
+++ b/src/endpoints/quests/starknetid/mod.rs
@@ -1,1 +1,4 @@
+pub mod verify_discord;
 pub mod verify_has_domain;
+pub mod verify_has_root_domain;
+pub mod verify_twitter;

--- a/src/endpoints/quests/starknetid/verify_discord.rs
+++ b/src/endpoints/quests/starknetid/verify_discord.rs
@@ -1,0 +1,164 @@
+use std::sync::Arc;
+
+use crate::models::AppState;
+use axum::{
+    extract::{Query, State},
+    http::StatusCode,
+    response::IntoResponse,
+    Json,
+};
+use mongodb::{bson::doc, options::UpdateOptions};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use starknet::{
+    core::types::{BlockId, CallFunction, FieldElement},
+    macros::{felt, selector, short_string},
+    providers::{Provider, SequencerGatewayProvider},
+};
+use std::str::FromStr;
+
+#[derive(Deserialize)]
+pub struct StarknetIdQuery {
+    addr: String,
+}
+
+#[derive(Deserialize)]
+pub struct CompletedTasks {
+    address: String,
+    task_id: u32,
+}
+
+#[derive(Serialize)]
+pub struct QueryError {
+    pub error: String,
+    pub res: bool,
+}
+
+pub async fn handler(
+    State(state): State<Arc<AppState>>,
+    Query(query): Query<StarknetIdQuery>,
+) -> impl IntoResponse {
+    let task_id = 7;
+    let addr = &query.addr;
+
+    // get starkname from address
+    let provider = SequencerGatewayProvider::starknet_alpha_mainnet();
+    let call_result = provider
+        .call_contract(
+            CallFunction {
+                contract_address: FieldElement::from_str(
+                    &state.conf.starknetid_contracts.naming_contract,
+                )
+                .unwrap(),
+                entry_point_selector: selector!("address_to_domain"),
+                calldata: vec![FieldElement::from_str(addr).unwrap()],
+            },
+            BlockId::Latest,
+        )
+        .await;
+
+    match call_result {
+        Ok(result) => {
+            // get starknet id from domain
+            let id_call_result = provider
+                .call_contract(
+                    CallFunction {
+                        contract_address: FieldElement::from_str(
+                            &state.conf.starknetid_contracts.naming_contract,
+                        )
+                        .unwrap(),
+                        entry_point_selector: selector!("domain_to_token_id"),
+                        calldata: result.result,
+                    },
+                    BlockId::Latest,
+                )
+                .await;
+
+            match id_call_result {
+                Ok(starknet_id) => {
+                    // get verifier data from starknet id
+                    let verifier_call_result = provider
+                        .call_contract(
+                            CallFunction {
+                                contract_address: FieldElement::from_str(
+                                    &state.conf.starknetid_contracts.identity_contract,
+                                )
+                                .unwrap(),
+                                entry_point_selector: selector!("get_verifier_data"),
+                                calldata: vec![
+                                    starknet_id.result[0],
+                                    short_string!("discord"),
+                                    FieldElement::from_str(
+                                        &state.conf.starknetid_contracts.verifier_contract,
+                                    )
+                                    .unwrap(),
+                                ],
+                            },
+                            BlockId::Latest,
+                        )
+                        .await;
+
+                    match verifier_call_result {
+                        Ok(verifier_data) => {
+                            if verifier_data.result[0] != felt!("0") {
+                                let completed_tasks_collection =
+                                    state.db.collection::<CompletedTasks>("completed_tasks");
+                                let filter = doc! { "address": addr, "task_id": task_id };
+                                let update = doc! { "$setOnInsert": { "address": addr, "task_id": task_id } };
+                                let options = UpdateOptions::builder().upsert(true).build();
+
+                                let result = completed_tasks_collection
+                                    .update_one(filter, update, options)
+                                    .await;
+
+                                match result {
+                                    Ok(_) => {
+                                        (StatusCode::OK, Json(json!({"res": true}))).into_response()
+                                    }
+                                    Err(e) => {
+                                        let error = QueryError {
+                                            error: format!("{}", e),
+                                            res: false,
+                                        };
+                                        (StatusCode::INTERNAL_SERVER_ERROR, Json(error))
+                                            .into_response()
+                                    }
+                                }
+                            } else {
+                                let error = QueryError {
+                                    error: String::from(
+                                        "You have not verified your Discord account",
+                                    ),
+                                    res: false,
+                                };
+                                (StatusCode::INTERNAL_SERVER_ERROR, Json(error)).into_response()
+                            }
+                        }
+                        Err(e) => {
+                            println!("error: {}", e);
+                            let error = QueryError {
+                                error: format!("{}", e),
+                                res: false,
+                            };
+                            (StatusCode::INTERNAL_SERVER_ERROR, Json(error)).into_response()
+                        }
+                    }
+                }
+                Err(e) => {
+                    let error = QueryError {
+                        error: format!("{}", e),
+                        res: false,
+                    };
+                    (StatusCode::INTERNAL_SERVER_ERROR, Json(error)).into_response()
+                }
+            }
+        }
+        Err(e) => {
+            let error = QueryError {
+                error: format!("{}", e),
+                res: false,
+            };
+            (StatusCode::INTERNAL_SERVER_ERROR, Json(error)).into_response()
+        }
+    }
+}

--- a/src/endpoints/quests/starknetid/verify_has_root_domain.rs
+++ b/src/endpoints/quests/starknetid/verify_has_root_domain.rs
@@ -38,7 +38,7 @@ pub async fn handler(
     State(state): State<Arc<AppState>>,
     Query(query): Query<StarknetIdQuery>,
 ) -> impl IntoResponse {
-    let task_id = 1;
+    let task_id = 5;
     let addr = &query.addr;
 
     // get starkname from address
@@ -62,7 +62,7 @@ pub async fn handler(
             let domain_len =
                 i64::from_str_radix(&FieldElement::to_string(&result.result[0]), 16).unwrap();
 
-            if domain_len > 0 {
+            if domain_len == 1 {
                 let completed_tasks_collection =
                     state.db.collection::<CompletedTasks>("completed_tasks");
                 let filter = doc! { "address": addr, "task_id": task_id };
@@ -85,7 +85,7 @@ pub async fn handler(
                 }
             } else {
                 let error = QueryError {
-                    error: String::from("You don't own a stark domain"),
+                    error: String::from("You don't own a .stark root domain"),
                     res: false,
                 };
                 (StatusCode::INTERNAL_SERVER_ERROR, Json(error)).into_response()

--- a/src/endpoints/quests/starknetid/verify_twitter.rs
+++ b/src/endpoints/quests/starknetid/verify_twitter.rs
@@ -1,0 +1,164 @@
+use std::sync::Arc;
+
+use crate::models::AppState;
+use axum::{
+    extract::{Query, State},
+    http::StatusCode,
+    response::IntoResponse,
+    Json,
+};
+use mongodb::{bson::doc, options::UpdateOptions};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use starknet::{
+    core::types::{BlockId, CallFunction, FieldElement},
+    macros::{felt, selector, short_string},
+    providers::{Provider, SequencerGatewayProvider},
+};
+use std::str::FromStr;
+
+#[derive(Deserialize)]
+pub struct StarknetIdQuery {
+    addr: String,
+}
+
+#[derive(Deserialize)]
+pub struct CompletedTasks {
+    address: String,
+    task_id: u32,
+}
+
+#[derive(Serialize)]
+pub struct QueryError {
+    pub error: String,
+    pub res: bool,
+}
+
+pub async fn handler(
+    State(state): State<Arc<AppState>>,
+    Query(query): Query<StarknetIdQuery>,
+) -> impl IntoResponse {
+    let task_id = 6;
+    let addr = &query.addr;
+
+    // get starkname from address
+    let provider = SequencerGatewayProvider::starknet_alpha_mainnet();
+    let call_result = provider
+        .call_contract(
+            CallFunction {
+                contract_address: FieldElement::from_str(
+                    &state.conf.starknetid_contracts.naming_contract,
+                )
+                .unwrap(),
+                entry_point_selector: selector!("address_to_domain"),
+                calldata: vec![FieldElement::from_str(addr).unwrap()],
+            },
+            BlockId::Latest,
+        )
+        .await;
+
+    match call_result {
+        Ok(result) => {
+            // get starknet id from domain
+            let id_call_result = provider
+                .call_contract(
+                    CallFunction {
+                        contract_address: FieldElement::from_str(
+                            &state.conf.starknetid_contracts.naming_contract,
+                        )
+                        .unwrap(),
+                        entry_point_selector: selector!("domain_to_token_id"),
+                        calldata: result.result,
+                    },
+                    BlockId::Latest,
+                )
+                .await;
+
+            match id_call_result {
+                Ok(starknet_id) => {
+                    // get verifier data from starknet id
+                    let verifier_call_result = provider
+                        .call_contract(
+                            CallFunction {
+                                contract_address: FieldElement::from_str(
+                                    &state.conf.starknetid_contracts.identity_contract,
+                                )
+                                .unwrap(),
+                                entry_point_selector: selector!("get_verifier_data"),
+                                calldata: vec![
+                                    starknet_id.result[0],
+                                    short_string!("twitter"),
+                                    FieldElement::from_str(
+                                        &state.conf.starknetid_contracts.verifier_contract,
+                                    )
+                                    .unwrap(),
+                                ],
+                            },
+                            BlockId::Latest,
+                        )
+                        .await;
+
+                    match verifier_call_result {
+                        Ok(verifier_data) => {
+                            if verifier_data.result[0] != felt!("0") {
+                                let completed_tasks_collection =
+                                    state.db.collection::<CompletedTasks>("completed_tasks");
+                                let filter = doc! { "address": addr, "task_id": task_id };
+                                let update = doc! { "$setOnInsert": { "address": addr, "task_id": task_id } };
+                                let options = UpdateOptions::builder().upsert(true).build();
+
+                                let result = completed_tasks_collection
+                                    .update_one(filter, update, options)
+                                    .await;
+
+                                match result {
+                                    Ok(_) => {
+                                        (StatusCode::OK, Json(json!({"res": true}))).into_response()
+                                    }
+                                    Err(e) => {
+                                        let error = QueryError {
+                                            error: format!("{}", e),
+                                            res: false,
+                                        };
+                                        (StatusCode::INTERNAL_SERVER_ERROR, Json(error))
+                                            .into_response()
+                                    }
+                                }
+                            } else {
+                                let error = QueryError {
+                                    error: String::from(
+                                        "You have not verified your Twitter account",
+                                    ),
+                                    res: false,
+                                };
+                                (StatusCode::INTERNAL_SERVER_ERROR, Json(error)).into_response()
+                            }
+                        }
+                        Err(e) => {
+                            println!("error: {}", e);
+                            let error = QueryError {
+                                error: format!("{}", e),
+                                res: false,
+                            };
+                            (StatusCode::INTERNAL_SERVER_ERROR, Json(error)).into_response()
+                        }
+                    }
+                }
+                Err(e) => {
+                    let error = QueryError {
+                        error: format!("{}", e),
+                        res: false,
+                    };
+                    (StatusCode::INTERNAL_SERVER_ERROR, Json(error)).into_response()
+                }
+            }
+        }
+        Err(e) => {
+            let error = QueryError {
+                error: format!("{}", e),
+                res: false,
+            };
+            (StatusCode::INTERNAL_SERVER_ERROR, Json(error)).into_response()
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,6 +70,18 @@ async fn main() {
             "/quests/starknetid/verify_has_domain",
             get(endpoints::quests::starknetid::verify_has_domain::handler),
         )
+        .route(
+            "/quests/starknetid/verify_has_root_domain",
+            get(endpoints::quests::starknetid::verify_has_root_domain::handler),
+        )
+        .route(
+            "/quests/starknetid/verify_twitter",
+            get(endpoints::quests::starknetid::verify_twitter::handler),
+        )
+        .route(
+            "/quests/starknetid/verify_discord",
+            get(endpoints::quests::starknetid::verify_discord::handler),
+        )
         .with_state(shared_state)
         .layer(cors);
 


### PR DESCRIPTION
Adds 3 new endpoints for starknet.id quests : 
- `verify_has_root_domain`
- `verify_twitter`
- `verify_discord`