### PR TITLE
fix: get_tasks query pipeline

### DIFF
--- a/src/endpoints/get_tasks.rs
+++ b/src/endpoints/get_tasks.rs
@@ -61,6 +61,7 @@ pub async fn handler(
                 "verify_endpoint": 1,
                 "desc": 1,
                 "completed": { "$gt": [ { "$size": "$completed" }, 0 ] },
+                "verify_endpoint_type": 1,
             }
         },
     ];


### PR DESCRIPTION
Fixes get_tasks query pipeline so it returns `verify_endpoint_type`