### PR TITLE
feat: hide hidden quests and block disabled ones

### DIFF
--- a/src/endpoints/get_quest.rs
+++ b/src/endpoints/get_quest.rs
@@ -21,7 +21,10 @@ pub async fn handler(
     Query(query): Query<GetQuestsQuery>,
 ) -> impl IntoResponse {
     let collection = state.db.collection::<QuestDocument>("quests");
-    match collection.find_one(doc! {"id": query.id}, None).await {
+    match collection
+        .find_one(doc! {"id": query.id, "disabled" : false}, None)
+        .await
+    {
         Ok(Some(quest)) => (StatusCode::OK, Json(quest)).into_response(),
         Ok(None) => get_error("Quest not found".to_string()),
         Err(_) => get_error("Error querying quest".to_string()),

--- a/src/endpoints/get_quests.rs
+++ b/src/endpoints/get_quests.rs
@@ -20,7 +20,13 @@ pub struct NFTItem {
 
 pub async fn handler(State(state): State<Arc<AppState>>) -> impl IntoResponse {
     let collection = state.db.collection::<QuestDocument>("quests");
-    match collection.find(None, None).await {
+    let filter = doc! {
+        "$and": [
+            {"disabled": false},
+            {"hidden": false}
+        ]
+    };
+    match collection.find(Some(filter), None).await {
         Ok(cursor) => {
             let quests: Vec<QuestDocument> = cursor.try_collect().await.unwrap_or_else(|_| vec![]);
             if quests.is_empty() {
@@ -29,6 +35,6 @@ pub async fn handler(State(state): State<Arc<AppState>>) -> impl IntoResponse {
                 (StatusCode::OK, Json(quests)).into_response()
             }
         }
-        Err(_) => get_error("Error querying quest".to_string()),
+        Err(_) => get_error("Error querying quests".to_string()),
     }
 }

--- a/src/endpoints/get_tasks.rs
+++ b/src/endpoints/get_tasks.rs
@@ -52,6 +52,16 @@ pub async fn handler(
             }
         },
         doc! {
+            "$lookup": {
+                "from": "quests",
+                "localField": "quest_id",
+                "foreignField": "id",
+                "as": "quest"
+            }
+        },
+        doc! { "$unwind": "$quest" },
+        doc! { "$match": { "quest.disabled": false } },
+        doc! {
             "$project": {
                 "_id": 0,
                 "id": 1,

--- a/src/models.rs
+++ b/src/models.rs
@@ -28,7 +28,8 @@ pub_struct!(Debug, Serialize, Deserialize; QuestDocument {
     rewards_nfts: Vec<NFTItem>,
     img_card: String,
     title_card: String,
-    finished: bool,
+    hidden: bool,
+    disabled: bool,
 });
 
 pub_struct!(Deserialize; CompletedTasks {


### PR DESCRIPTION
This pull request replaces the "disabled" field from existing `quests` collection scheme by two new fields. Disabling a quest used to just be front end trick to hide a quest from the front page of the website. People could still find the quest id by looking at the API result and access it. Here is how this feature changes that:

### 1) ``disabled``
A disabled quest won't be accessible. You won't be able to find it in the list of quests, nor fetch the actual quest document required to display the quest page. Endpoints allowing to complete the tasks of this quest will still work so we should still update the quest server when we remove a quest, but this allows us to keep the database as it is.

### 2) ``hidden``
This is similar to what we used to do when disabling quests, except this is server-side. You can still access the actual quest page, but even if you look at the API result, you won't be able to find the quest_id in the returned json.