### PR TITLE
fix: add check addr 0 in verify twitter tasks

### DIFF
--- a/src/endpoints/quests/orbiter/verify_twitter_fw.rs
+++ b/src/endpoints/quests/orbiter/verify_twitter_fw.rs
@@ -11,12 +11,16 @@ use axum::{
     Json,
 };
 use serde_json::json;
+use starknet::core::types::FieldElement;
 
 pub async fn handler(
     State(state): State<Arc<AppState>>,
     Query(query): Query<VerifyQuery>,
 ) -> impl IntoResponse {
     let task_id = 34;
+    if query.addr == FieldElement::ZERO {
+        return get_error("Please connect your wallet first".to_string());
+    }
     match state.upsert_completed_task(query.addr, task_id).await {
         Ok(_) => (StatusCode::OK, Json(json!({"res": true}))).into_response(),
         Err(e) => get_error(format!("{}", e)),

--- a/src/endpoints/quests/orbiter/verify_twitter_fw_sq.rs
+++ b/src/endpoints/quests/orbiter/verify_twitter_fw_sq.rs
@@ -11,12 +11,16 @@ use axum::{
     Json,
 };
 use serde_json::json;
+use starknet::core::types::FieldElement;
 
 pub async fn handler(
     State(state): State<Arc<AppState>>,
     Query(query): Query<VerifyQuery>,
 ) -> impl IntoResponse {
     let task_id = 35;
+    if query.addr == FieldElement::ZERO {
+        return get_error("Please connect your wallet first".to_string());
+    }
     match state.upsert_completed_task(query.addr, task_id).await {
         Ok(_) => (StatusCode::OK, Json(json!({"res": true}))).into_response(),
         Err(e) => get_error(format!("{}", e)),

--- a/src/endpoints/quests/orbiter/verify_twitter_rt.rs
+++ b/src/endpoints/quests/orbiter/verify_twitter_rt.rs
@@ -11,12 +11,16 @@ use axum::{
     Json,
 };
 use serde_json::json;
+use starknet::core::types::FieldElement;
 
 pub async fn handler(
     State(state): State<Arc<AppState>>,
     Query(query): Query<VerifyQuery>,
 ) -> impl IntoResponse {
     let task_id = 36;
+    if query.addr == FieldElement::ZERO {
+        return get_error("Please connect your wallet first".to_string());
+    }
     match state.upsert_completed_task(query.addr, task_id).await {
         Ok(_) => (StatusCode::OK, Json(json!({"res": true}))).into_response(),
         Err(e) => get_error(format!("{}", e)),

--- a/src/endpoints/quests/sithswap/verify_twitter_fw.rs
+++ b/src/endpoints/quests/sithswap/verify_twitter_fw.rs
@@ -11,12 +11,16 @@ use axum::{
     Json,
 };
 use serde_json::json;
+use starknet::core::types::FieldElement;
 
 pub async fn handler(
     State(state): State<Arc<AppState>>,
     Query(query): Query<VerifyQuery>,
 ) -> impl IntoResponse {
     let task_id = 21;
+    if query.addr == FieldElement::ZERO {
+        return get_error("Please connect your wallet first".to_string());
+    }
     match state.upsert_completed_task(query.addr, task_id).await {
         Ok(_) => (StatusCode::OK, Json(json!({"res": true}))).into_response(),
         Err(e) => get_error(format!("{}", e)),

--- a/src/endpoints/quests/sithswap/verify_twitter_rt.rs
+++ b/src/endpoints/quests/sithswap/verify_twitter_rt.rs
@@ -11,12 +11,16 @@ use axum::{
     Json,
 };
 use serde_json::json;
+use starknet::core::types::FieldElement;
 
 pub async fn handler(
     State(state): State<Arc<AppState>>,
     Query(query): Query<VerifyQuery>,
 ) -> impl IntoResponse {
     let task_id = 22;
+    if query.addr == FieldElement::ZERO {
+        return get_error("Please connect your wallet first".to_string());
+    }
     match state.upsert_completed_task(query.addr, task_id).await {
         Ok(_) => (StatusCode::OK, Json(json!({"res": true}))).into_response(),
         Err(e) => get_error(format!("{}", e)),

--- a/src/endpoints/quests/starknetid/verify_twitter_fw.rs
+++ b/src/endpoints/quests/starknetid/verify_twitter_fw.rs
@@ -11,12 +11,16 @@ use axum::{
     Json,
 };
 use serde_json::json;
+use starknet::core::types::FieldElement;
 
 pub async fn handler(
     State(state): State<Arc<AppState>>,
     Query(query): Query<VerifyQuery>,
 ) -> impl IntoResponse {
     let task_id = 7;
+    if query.addr == FieldElement::ZERO {
+        return get_error("Please connect your wallet first".to_string());
+    }
     match state.upsert_completed_task(query.addr, task_id).await {
         Ok(_) => (StatusCode::OK, Json(json!({"res": true}))).into_response(),
         Err(e) => get_error(format!("{}", e)),


### PR DESCRIPTION
This PR adds a checks in `verify_twitter_` endpoints so that it's not possible to verify this task if the value of the query param `addr` is 0. It will return an error message. 