### PR TITLE
feat: add new layout for text_choice quiz question

### DIFF
--- a/config.template.toml
+++ b/config.template.toml
@@ -65,3 +65,11 @@ layout = "default"
 question = "Arrange these numbers in ascending order:"
 options = ["3", "1", "2", "4"]
 correct_order = [2, 3, 1, 4]
+
+[[quizzes.example.questions]]
+kind = "text_choice"
+layout = "illustrated_left"
+question = "Which number is represented on the image?"
+options = ["1", "2"]
+correct_answer = [1]
+image_for_layout = "/example/one.webp"

--- a/src/config.rs
+++ b/src/config.rs
@@ -83,6 +83,7 @@ pub_struct!(Clone, Deserialize; QuizQuestion {
     options: Vec<String>,
     correct_answers: Option<Vec<usize>>,
     correct_order: Option<Vec<usize>>,
+    image_for_layout: Option<String>,
 });
 
 pub_struct!(Clone, Deserialize; Quiz {

--- a/src/endpoints/get_quiz.rs
+++ b/src/endpoints/get_quiz.rs
@@ -23,6 +23,7 @@ pub_struct!(Clone, Serialize; QuizQuestionResp {
     layout: String,
     question: String,
     options: Vec<String>,
+    image_for_layout: Option<String>
 });
 
 #[derive(Clone, Serialize)]
@@ -52,6 +53,7 @@ pub async fn handler(
                     layout: question.layout.clone(),
                     question: question.question.clone(),
                     options: question.options.clone(),
+                    image_for_layout: question.image_for_layout.clone(),
                 })
                 .collect();
             let quiz_response = QuizResponse {


### PR DESCRIPTION
This PR adds the possibility to add an image on text_choice questions. 
It adds a new example question with `illustrated_left` layout. 