### PR TITLE
feat: add an example/verify_quiz route

### DIFF
--- a/src/endpoints/quests/example/mod.rs
+++ b/src/endpoints/quests/example/mod.rs
@@ -1,0 +1,1 @@
+pub mod verify_quiz;

--- a/src/endpoints/quests/example/verify_quiz.rs
+++ b/src/endpoints/quests/example/verify_quiz.rs
@@ -1,0 +1,42 @@
+use std::sync::Arc;
+
+use crate::{
+    common::verify_quiz::verify_quiz,
+    models::{AppState, VerifyQuizQuery},
+    utils::{get_error, CompletedTasksTrait},
+};
+use axum::{extract::State, http::StatusCode, response::IntoResponse, Json};
+use serde_json::json;
+use starknet::core::types::FieldElement;
+
+pub async fn handler(
+    State(state): State<Arc<AppState>>,
+    body: Json<VerifyQuizQuery>,
+) -> impl IntoResponse {
+    let task_id = 999;
+    if body.addr == FieldElement::ZERO {
+        return get_error("Please connect your wallet first".to_string());
+    }
+
+    let user_answers_numbers: Result<Vec<Vec<usize>>, _> = body
+        .user_answers_list
+        .iter()
+        .map(|inner_list| {
+            inner_list
+                .iter()
+                .map(|s| s.parse::<usize>())
+                .collect::<Result<Vec<_>, _>>()
+        })
+        .collect();
+
+    match user_answers_numbers {
+        Ok(responses) => match verify_quiz(&state.conf, body.addr, &body.quiz_name, &responses) {
+            true => match state.upsert_completed_task(body.addr, task_id).await {
+                Ok(_) => (StatusCode::OK, Json(json!({"res": true}))).into_response(),
+                Err(e) => get_error(format!("{}", e)),
+            },
+            false => get_error("Incorrect answers".to_string()),
+        },
+        Err(e) => get_error(format!("{}", e)),
+    }
+}

--- a/src/endpoints/quests/mod.rs
+++ b/src/endpoints/quests/mod.rs
@@ -1,4 +1,5 @@
 pub mod contract_uri;
+pub mod example;
 pub mod orbiter;
 pub mod sithswap;
 pub mod starknetid;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,11 @@ mod common;
 mod config;
 mod endpoints;
 mod models;
-use axum::{http::StatusCode, routing::get, Router};
+use axum::{
+    http::StatusCode,
+    routing::{get, post},
+    Router,
+};
 use mongodb::{bson::doc, options::ClientOptions, Client};
 use reqwest::{Proxy, Url};
 use starknet::providers::SequencerGatewayProvider;
@@ -150,6 +154,10 @@ async fn main() {
         .route(
             "/quests/orbiter/claimable",
             get(endpoints::quests::orbiter::claimable::handler),
+        )
+        .route(
+            "/quests/example/verify_quiz",
+            post(endpoints::quests::example::verify_quiz::handler),
         )
         .with_state(shared_state)
         .layer(cors);

--- a/src/models.rs
+++ b/src/models.rs
@@ -59,3 +59,9 @@ pub_struct!(Serialize; RewardResponse {
 pub_struct!(Deserialize; VerifyQuery {
      addr: FieldElement,
 });
+
+pub_struct!(Deserialize; VerifyQuizQuery {
+    addr: FieldElement,
+    quiz_name: String,
+    user_answers_list: Vec<Vec<String>>,
+});


### PR DESCRIPTION
Adds a new route `example/verify_quiz` so we can test verifying a quiz in the frontend