### PR TITLE
feat: update defi quests

### DIFF
--- a/config.template.toml
+++ b/config.template.toml
@@ -18,6 +18,11 @@ identity_contract = "0xXXXXXXXXXXXX"
 [quests.sithswap]
 utils_contract = "0xXXXXXXXXXXXX"
 pairs = ["0xXXXXXXXXXXXX"]
+[quests.jediswap]
+utils_contract = "0xXXXXXXXXXXXX"
+pairs = ["0xXXXXXXXXXXXX"]
+[quests.zklend]
+contract = "0xXXXXXXXXXXXX"
 
 [twitter]
 oauth2_clientid = "xxxxxx"

--- a/src/config.rs
+++ b/src/config.rs
@@ -40,8 +40,19 @@ pub_struct!(Clone, Deserialize;  Sithswap {
     pairs : Vec<FieldElement>,
 });
 
+pub_struct!(Clone, Deserialize;  Zklend {
+    contract: FieldElement,
+});
+
+pub_struct!(Clone, Deserialize;  Jediswap {
+    utils_contract: FieldElement,
+    pairs : Vec<FieldElement>,
+});
+
 pub_struct!(Clone, Deserialize;  Quests {
     sithswap: Sithswap,
+    zklend: Zklend,
+    jediswap: Jediswap,
 });
 
 pub_struct!(Clone, Deserialize;  Twitter {

--- a/src/endpoints/quests/avnu/claimable.rs
+++ b/src/endpoints/quests/avnu/claimable.rs
@@ -1,0 +1,101 @@
+use crate::models::{AppState, CompletedTaskDocument, Reward, RewardResponse};
+use crate::utils::{get_error, get_nft};
+use axum::{
+    extract::{Query, State},
+    http::StatusCode,
+    response::IntoResponse,
+    Json,
+};
+use futures::StreamExt;
+use mongodb::bson::doc;
+use serde::Deserialize;
+use starknet::{
+    core::types::FieldElement,
+    signers::{LocalWallet, SigningKey},
+};
+use std::sync::Arc;
+
+const QUEST_ID: u32 = 3;
+const TASK_IDS: &[u32] = &[12, 13, 14, 15];
+const LAST_TASK: u32 = TASK_IDS[3];
+const NFT_LEVEL: u32 = 6;
+
+#[derive(Deserialize)]
+pub struct ClaimableQuery {
+    addr: FieldElement,
+}
+
+pub async fn handler(
+    State(state): State<Arc<AppState>>,
+    Query(query): Query<ClaimableQuery>,
+) -> impl IntoResponse {
+    let collection = state
+        .db
+        .collection::<CompletedTaskDocument>("completed_tasks");
+
+    let pipeline = vec![
+        doc! {
+            "$match": {
+                "address": &query.addr.to_string(),
+                "task_id": { "$in": TASK_IDS },
+            },
+        },
+        doc! {
+            "$lookup": {
+                "from": "tasks",
+                "localField": "task_id",
+                "foreignField": "id",
+                "as": "task",
+            },
+        },
+        doc! {
+            "$match": {
+                "task.quest_id": QUEST_ID,
+            },
+        },
+        doc! {
+            "$group": {
+                "_id": "$address",
+                "completed_tasks": { "$push": "$task_id" },
+            },
+        },
+        doc! {
+            "$match": {
+                "completed_tasks": { "$all": TASK_IDS },
+            },
+        },
+    ];
+
+    let completed_tasks = collection.aggregate(pipeline, None).await;
+    match completed_tasks {
+        Ok(mut tasks_cursor) => {
+            if tasks_cursor.next().await.is_none() {
+                return get_error("User hasn't completed all tasks".into());
+            }
+
+            let signer = LocalWallet::from(SigningKey::from_secret_scalar(
+                state.conf.nft_contract.private_key,
+            ));
+
+            let mut rewards = vec![];
+
+            let  Ok((token_id, sig)) = get_nft(QUEST_ID, LAST_TASK, &query.addr, NFT_LEVEL, &signer).await else {
+                return get_error("Signature failed".into());
+               };
+
+            rewards.push(Reward {
+                task_id: LAST_TASK,
+                nft_contract: state.conf.nft_contract.address.clone(),
+                token_id: token_id.to_string(),
+                sig: (sig.r, sig.s),
+            });
+
+            if rewards.is_empty() {
+                get_error("No rewards found for this user".into())
+            } else {
+                (StatusCode::OK, Json(RewardResponse { rewards })).into_response()
+            }
+        }
+        Err(_) => get_error("Error querying rewards".into()),
+    }
+}

--- a/src/endpoints/quests/avnu/discord_fw_callback.rs
+++ b/src/endpoints/quests/avnu/discord_fw_callback.rs
@@ -1,0 +1,145 @@
+use std::sync::Arc;
+
+use crate::utils::CompletedTasksTrait;
+use crate::{
+    models::AppState,
+    utils::{get_error_redirect, success_redirect},
+};
+use axum::{
+    extract::{Query, State},
+    response::IntoResponse,
+};
+use mongodb::bson::doc;
+use reqwest::header::AUTHORIZATION;
+use serde::Deserialize;
+use starknet::core::types::FieldElement;
+
+#[derive(Deserialize)]
+pub struct TwitterOAuthCallbackQuery {
+    code: String,
+    state: FieldElement,
+}
+
+#[derive(Deserialize)]
+pub struct Guild {
+    id: String,
+    #[allow(dead_code)]
+    name: String,
+}
+
+pub async fn handler(
+    State(state): State<Arc<AppState>>,
+    Query(query): Query<TwitterOAuthCallbackQuery>,
+) -> impl IntoResponse {
+    let quest_id = 3;
+    let task_id = 13;
+    let guild_id = "942355887270559774";
+    let authorization_code = &query.code;
+    let error_redirect_uri = format!(
+        "{}/quest/{}?task_id={}&res=false",
+        state.conf.variables.app_link, quest_id, task_id
+    );
+
+    // Exchange the authorization code for an access token
+    let params = [
+        ("client_id", &state.conf.discord.oauth2_clientid),
+        ("client_secret", &state.conf.discord.oauth2_secret),
+        ("code", &authorization_code.to_string()),
+        (
+            "redirect_uri",
+            &format!(
+                "{}/quests/avnu/discord_fw_callback",
+                state.conf.variables.api_link
+            ),
+        ),
+        ("grant_type", &"authorization_code".to_string()),
+    ];
+    let access_token = match exchange_authorization_code(params).await {
+        Ok(token) => token,
+        Err(e) => {
+            return get_error_redirect(
+                error_redirect_uri,
+                format!("Failed to exchange authorization code: {}", e),
+            );
+        }
+    };
+
+    // Get user guild information
+    let client = reqwest::Client::new();
+    let response_result = client
+        .get("https://discord.com/api/users/@me/guilds")
+        .header(AUTHORIZATION, format!("Bearer {}", access_token))
+        .send()
+        .await;
+    let response: Vec<Guild> = match response_result {
+        Ok(response) => {
+            let json_result = response.json().await;
+            match json_result {
+                Ok(json) => json,
+                Err(e) => {
+                    return get_error_redirect(
+                        error_redirect_uri,
+                        format!(
+                            "Failed to get JSON response while fetching user info: {}",
+                            e
+                        ),
+                    );
+                }
+            }
+        }
+        Err(e) => {
+            return get_error_redirect(
+                error_redirect_uri,
+                format!("Failed to send request to get user info: {}", e),
+            );
+        }
+    };
+
+    for guild in response {
+        if guild.id == guild_id {
+            match state.upsert_completed_task(query.state, task_id).await {
+                Ok(_) => {
+                    let redirect_uri = format!(
+                        "{}/quest/{}?task_id={}&res=true",
+                        state.conf.variables.app_link, quest_id, task_id
+                    );
+                    return success_redirect(redirect_uri);
+                }
+                Err(e) => return get_error_redirect(error_redirect_uri, format!("{}", e)),
+            }
+        }
+    }
+
+    get_error_redirect(
+        error_redirect_uri,
+        "You're not part of AVNU's Discord server".to_string(),
+    )
+}
+
+async fn exchange_authorization_code(
+    params: [(&str, &String); 5],
+) -> Result<String, Box<dyn std::error::Error>> {
+    let client = reqwest::Client::new();
+    let res = client
+        .post("https://discord.com/api/oauth2/token")
+        .form(&params)
+        .send()
+        .await?;
+    let json: serde_json::Value = res.json().await?;
+    match json["access_token"].as_str() {
+        Some(s) => Ok(s.to_string()),
+        None => {
+            println!(
+                "Failed to get 'access_token' from JSON response : {:?}",
+                json
+            );
+            Err(Box::new(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                format!(
+                    "Failed to get 'access_token' from JSON response : {:?}",
+                    json
+                ),
+            )))
+        }
+    }
+}

--- a/src/endpoints/quests/avnu/mod.rs
+++ b/src/endpoints/quests/avnu/mod.rs
@@ -1,0 +1,5 @@
+pub mod claimable;
+pub mod discord_fw_callback;
+pub mod verify_swap;
+pub mod verify_twitter_fw;
+pub mod verify_twitter_rt;

--- a/src/endpoints/quests/avnu/verify_swap.rs
+++ b/src/endpoints/quests/avnu/verify_swap.rs
@@ -1,0 +1,58 @@
+use std::sync::Arc;
+
+use crate::{
+    models::{AppState, VerifyQuery},
+    utils::{get_error, CompletedTasksTrait},
+};
+use axum::{
+    extract::{Query, State},
+    http::StatusCode,
+    response::IntoResponse,
+    Json,
+};
+use serde_json::json;
+
+pub async fn handler(
+    State(state): State<Arc<AppState>>,
+    Query(query): Query<VerifyQuery>,
+) -> impl IntoResponse {
+    let task_id = 12;
+    let hex_addr = format!("{:#x}", query.addr);
+
+    // Fetch AVNU endpoint to get user score
+    let url = format!("https://starknet.api.avnu.fi/v1/takers/{}", hex_addr);
+    let client = reqwest::Client::new();
+    let response_result = client.get(url).send().await;
+    let response = match response_result {
+        Ok(response) => {
+            let json_result = response.json::<serde_json::Value>().await;
+            match json_result {
+                Ok(json) => json,
+                Err(e) => {
+                    return get_error(format!(
+                        "Failed to get JSON response while fetching user info: {}",
+                        e
+                    ));
+                }
+            }
+        }
+        Err(e) => {
+            return get_error(format!("Failed to send request to fetch user info: {}", e));
+        }
+    };
+    let score = match response["score"].as_u64() {
+        Some(s) => s,
+        None => {
+            return get_error("Failed to get user info from response data".to_string());
+        }
+    };
+
+    if score == 0 {
+        get_error("You have not made a swap on AVNU yet.".to_string())
+    } else {
+        match state.upsert_completed_task(query.addr, task_id).await {
+            Ok(_) => (StatusCode::OK, Json(json!({"res": true}))).into_response(),
+            Err(e) => get_error(format!("{}", e)),
+        }
+    }
+}

--- a/src/endpoints/quests/avnu/verify_twitter_fw.rs
+++ b/src/endpoints/quests/avnu/verify_twitter_fw.rs
@@ -1,0 +1,24 @@
+use std::sync::Arc;
+
+use crate::{
+    models::{AppState, VerifyQuery},
+    utils::{get_error, CompletedTasksTrait},
+};
+use axum::{
+    extract::{Query, State},
+    http::StatusCode,
+    response::IntoResponse,
+    Json,
+};
+use serde_json::json;
+
+pub async fn handler(
+    State(state): State<Arc<AppState>>,
+    Query(query): Query<VerifyQuery>,
+) -> impl IntoResponse {
+    let task_id = 14;
+    match state.upsert_completed_task(query.addr, task_id).await {
+        Ok(_) => (StatusCode::OK, Json(json!({"res": true}))).into_response(),
+        Err(e) => get_error(format!("{}", e)),
+    }
+}

--- a/src/endpoints/quests/avnu/verify_twitter_rt.rs
+++ b/src/endpoints/quests/avnu/verify_twitter_rt.rs
@@ -1,0 +1,24 @@
+use std::sync::Arc;
+
+use crate::{
+    models::{AppState, VerifyQuery},
+    utils::{get_error, CompletedTasksTrait},
+};
+use axum::{
+    extract::{Query, State},
+    http::StatusCode,
+    response::IntoResponse,
+    Json,
+};
+use serde_json::json;
+
+pub async fn handler(
+    State(state): State<Arc<AppState>>,
+    Query(query): Query<VerifyQuery>,
+) -> impl IntoResponse {
+    let task_id = 15;
+    match state.upsert_completed_task(query.addr, task_id).await {
+        Ok(_) => (StatusCode::OK, Json(json!({"res": true}))).into_response(),
+        Err(e) => get_error(format!("{}", e)),
+    }
+}

--- a/src/endpoints/quests/jediswap/claimable.rs
+++ b/src/endpoints/quests/jediswap/claimable.rs
@@ -1,0 +1,101 @@
+use crate::models::{AppState, CompletedTaskDocument, Reward, RewardResponse};
+use crate::utils::{get_error, get_nft};
+use axum::{
+    extract::{Query, State},
+    http::StatusCode,
+    response::IntoResponse,
+    Json,
+};
+use futures::StreamExt;
+use mongodb::bson::doc;
+use serde::Deserialize;
+use starknet::{
+    core::types::FieldElement,
+    signers::{LocalWallet, SigningKey},
+};
+use std::sync::Arc;
+
+const QUEST_ID: u32 = 2;
+const TASK_IDS: &[u32] = &[8, 9, 10, 11];
+const LAST_TASK: u32 = TASK_IDS[3];
+const NFT_LEVEL: u32 = 5;
+
+#[derive(Deserialize)]
+pub struct ClaimableQuery {
+    addr: FieldElement,
+}
+
+pub async fn handler(
+    State(state): State<Arc<AppState>>,
+    Query(query): Query<ClaimableQuery>,
+) -> impl IntoResponse {
+    let collection = state
+        .db
+        .collection::<CompletedTaskDocument>("completed_tasks");
+
+    let pipeline = vec![
+        doc! {
+            "$match": {
+                "address": &query.addr.to_string(),
+                "task_id": { "$in": TASK_IDS },
+            },
+        },
+        doc! {
+            "$lookup": {
+                "from": "tasks",
+                "localField": "task_id",
+                "foreignField": "id",
+                "as": "task",
+            },
+        },
+        doc! {
+            "$match": {
+                "task.quest_id": QUEST_ID,
+            },
+        },
+        doc! {
+            "$group": {
+                "_id": "$address",
+                "completed_tasks": { "$push": "$task_id" },
+            },
+        },
+        doc! {
+            "$match": {
+                "completed_tasks": { "$all": TASK_IDS },
+            },
+        },
+    ];
+
+    let completed_tasks = collection.aggregate(pipeline, None).await;
+    match completed_tasks {
+        Ok(mut tasks_cursor) => {
+            if tasks_cursor.next().await.is_none() {
+                return get_error("User hasn't completed all tasks".into());
+            }
+
+            let signer = LocalWallet::from(SigningKey::from_secret_scalar(
+                state.conf.nft_contract.private_key,
+            ));
+
+            let mut rewards = vec![];
+
+            let  Ok((token_id, sig)) = get_nft(QUEST_ID, LAST_TASK, &query.addr, NFT_LEVEL, &signer).await else {
+                return get_error("Signature failed".into());
+               };
+
+            rewards.push(Reward {
+                task_id: LAST_TASK,
+                nft_contract: state.conf.nft_contract.address.clone(),
+                token_id: token_id.to_string(),
+                sig: (sig.r, sig.s),
+            });
+
+            if rewards.is_empty() {
+                get_error("No rewards found for this user".into())
+            } else {
+                (StatusCode::OK, Json(RewardResponse { rewards })).into_response()
+            }
+        }
+        Err(_) => get_error("Error querying rewards".into()),
+    }
+}

--- a/src/endpoints/quests/jediswap/mod.rs
+++ b/src/endpoints/quests/jediswap/mod.rs
@@ -1,0 +1,5 @@
+pub mod claimable;
+pub mod verify_added_liquidity;
+pub mod verify_has_root_domain;
+pub mod verify_twitter_fw;
+pub mod verify_twitter_rt;

--- a/src/endpoints/quests/jediswap/verify_added_liquidity.rs
+++ b/src/endpoints/quests/jediswap/verify_added_liquidity.rs
@@ -1,0 +1,55 @@
+use std::sync::Arc;
+
+use crate::{
+    models::{AppState, VerifyQuery},
+    utils::{get_error, CompletedTasksTrait},
+};
+use axum::{
+    extract::{Query, State},
+    http::StatusCode,
+    response::IntoResponse,
+    Json,
+};
+use serde_json::json;
+use starknet::{
+    core::types::{BlockId, CallFunction, FieldElement},
+    macros::selector,
+    providers::Provider,
+};
+
+pub async fn handler(
+    State(state): State<Arc<AppState>>,
+    Query(query): Query<VerifyQuery>,
+) -> impl IntoResponse {
+    let task_id = 9;
+    let addr = &query.addr;
+    let mut calldata = vec![addr.clone(), state.conf.quests.jediswap.pairs.len().into()];
+    calldata.append(&mut state.conf.quests.jediswap.pairs.clone());
+
+    // get starkname from address
+    let call_result = state
+        .provider
+        .call_contract(
+            CallFunction {
+                contract_address: state.conf.quests.jediswap.utils_contract,
+                entry_point_selector: selector!("sum_balances"),
+                calldata,
+            },
+            BlockId::Latest,
+        )
+        .await;
+
+    match call_result {
+        Ok(result) => {
+            if result.result[0] == FieldElement::ZERO {
+                get_error("You didn't deposit liquidity.".to_string())
+            } else {
+                match state.upsert_completed_task(query.addr, task_id).await {
+                    Ok(_) => (StatusCode::OK, Json(json!({"res": true}))).into_response(),
+                    Err(e) => get_error(format!("{}", e)),
+                }
+            }
+        }
+        Err(e) => get_error(format!("{}", e)),
+    }
+}

--- a/src/endpoints/quests/jediswap/verify_has_root_domain.rs
+++ b/src/endpoints/quests/jediswap/verify_has_root_domain.rs
@@ -1,0 +1,16 @@
+use crate::{
+    common::verify_has_root_domain::execute_has_root_domain,
+    models::{AppState, VerifyQuery},
+};
+use axum::{
+    extract::{Query, State},
+    response::IntoResponse,
+};
+use std::sync::Arc;
+
+pub async fn handler(
+    State(state): State<Arc<AppState>>,
+    Query(query): Query<VerifyQuery>,
+) -> impl IntoResponse {
+    execute_has_root_domain(state, &query.addr, 8).await
+}

--- a/src/endpoints/quests/jediswap/verify_twitter_fw.rs
+++ b/src/endpoints/quests/jediswap/verify_twitter_fw.rs
@@ -1,0 +1,24 @@
+use std::sync::Arc;
+
+use crate::{
+    models::{AppState, VerifyQuery},
+    utils::{get_error, CompletedTasksTrait},
+};
+use axum::{
+    extract::{Query, State},
+    http::StatusCode,
+    response::IntoResponse,
+    Json,
+};
+use serde_json::json;
+
+pub async fn handler(
+    State(state): State<Arc<AppState>>,
+    Query(query): Query<VerifyQuery>,
+) -> impl IntoResponse {
+    let task_id = 10;
+    match state.upsert_completed_task(query.addr, task_id).await {
+        Ok(_) => (StatusCode::OK, Json(json!({"res": true}))).into_response(),
+        Err(e) => get_error(format!("{}", e)),
+    }
+}

--- a/src/endpoints/quests/jediswap/verify_twitter_rt.rs
+++ b/src/endpoints/quests/jediswap/verify_twitter_rt.rs
@@ -1,0 +1,24 @@
+use std::sync::Arc;
+
+use crate::{
+    models::{AppState, VerifyQuery},
+    utils::{get_error, CompletedTasksTrait},
+};
+use axum::{
+    extract::{Query, State},
+    http::StatusCode,
+    response::IntoResponse,
+    Json,
+};
+use serde_json::json;
+
+pub async fn handler(
+    State(state): State<Arc<AppState>>,
+    Query(query): Query<VerifyQuery>,
+) -> impl IntoResponse {
+    let task_id = 11;
+    match state.upsert_completed_task(query.addr, task_id).await {
+        Ok(_) => (StatusCode::OK, Json(json!({"res": true}))).into_response(),
+        Err(e) => get_error(format!("{}", e)),
+    }
+}

--- a/src/endpoints/quests/mod.rs
+++ b/src/endpoints/quests/mod.rs
@@ -1,6 +1,9 @@
+pub mod avnu;
 pub mod contract_uri;
+pub mod jediswap;
 pub mod orbiter;
 pub mod sithswap;
 pub mod starknetid;
 pub mod tribe;
 pub mod uri;
+pub mod zklend;

--- a/src/endpoints/quests/zklend/claimable.rs
+++ b/src/endpoints/quests/zklend/claimable.rs
@@ -1,0 +1,101 @@
+use crate::models::{AppState, CompletedTaskDocument, Reward, RewardResponse};
+use crate::utils::{get_error, get_nft};
+use axum::{
+    extract::{Query, State},
+    http::StatusCode,
+    response::IntoResponse,
+    Json,
+};
+use futures::StreamExt;
+use mongodb::bson::doc;
+use serde::Deserialize;
+use starknet::{
+    core::types::FieldElement,
+    signers::{LocalWallet, SigningKey},
+};
+use std::sync::Arc;
+
+const QUEST_ID: u32 = 6;
+const TASK_IDS: &[u32] = &[23, 24, 26, 27];
+const LAST_TASK: u32 = TASK_IDS[3];
+const NFT_LEVEL: u32 = 8;
+
+#[derive(Deserialize)]
+pub struct ClaimableQuery {
+    addr: FieldElement,
+}
+
+pub async fn handler(
+    State(state): State<Arc<AppState>>,
+    Query(query): Query<ClaimableQuery>,
+) -> impl IntoResponse {
+    let collection = state
+        .db
+        .collection::<CompletedTaskDocument>("completed_tasks");
+
+    let pipeline = vec![
+        doc! {
+            "$match": {
+                "address": &query.addr.to_string(),
+                "task_id": { "$in": TASK_IDS },
+            },
+        },
+        doc! {
+            "$lookup": {
+                "from": "tasks",
+                "localField": "task_id",
+                "foreignField": "id",
+                "as": "task",
+            },
+        },
+        doc! {
+            "$match": {
+                "task.quest_id": QUEST_ID,
+            },
+        },
+        doc! {
+            "$group": {
+                "_id": "$address",
+                "completed_tasks": { "$push": "$task_id" },
+            },
+        },
+        doc! {
+            "$match": {
+                "completed_tasks": { "$all": TASK_IDS },
+            },
+        },
+    ];
+
+    let completed_tasks = collection.aggregate(pipeline, None).await;
+    match completed_tasks {
+        Ok(mut tasks_cursor) => {
+            if tasks_cursor.next().await.is_none() {
+                return get_error("User hasn't completed all tasks".into());
+            }
+
+            let signer = LocalWallet::from(SigningKey::from_secret_scalar(
+                state.conf.nft_contract.private_key,
+            ));
+
+            let mut rewards = vec![];
+
+            let  Ok((token_id, sig)) = get_nft(QUEST_ID, LAST_TASK, &query.addr, NFT_LEVEL, &signer).await else {
+                return get_error("Signature failed".into());
+               };
+
+            rewards.push(Reward {
+                task_id: LAST_TASK,
+                nft_contract: state.conf.nft_contract.address.clone(),
+                token_id: token_id.to_string(),
+                sig: (sig.r, sig.s),
+            });
+
+            if rewards.is_empty() {
+                get_error("No rewards found for this user".into())
+            } else {
+                (StatusCode::OK, Json(RewardResponse { rewards })).into_response()
+            }
+        }
+        Err(_) => get_error("Error querying rewards".into()),
+    }
+}

--- a/src/endpoints/quests/zklend/mod.rs
+++ b/src/endpoints/quests/zklend/mod.rs
@@ -1,0 +1,5 @@
+pub mod claimable;
+pub mod verify_borrow;
+pub mod verify_has_root_domain;
+pub mod verify_twitter_fw;
+pub mod verify_twitter_rt;

--- a/src/endpoints/quests/zklend/verify_borrow.rs
+++ b/src/endpoints/quests/zklend/verify_borrow.rs
@@ -1,0 +1,53 @@
+use std::sync::Arc;
+
+use crate::{
+    models::{AppState, VerifyQuery},
+    utils::{get_error, CompletedTasksTrait},
+};
+use axum::{
+    extract::{Query, State},
+    http::StatusCode,
+    response::IntoResponse,
+    Json,
+};
+use serde_json::json;
+use starknet::{
+    core::types::{BlockId, CallFunction, FieldElement},
+    macros::selector,
+    providers::Provider,
+};
+
+pub async fn handler(
+    State(state): State<Arc<AppState>>,
+    Query(query): Query<VerifyQuery>,
+) -> impl IntoResponse {
+    let task_id = 24;
+    let addr = &query.addr;
+
+    // check if user has debt
+    let call_result = state
+        .provider
+        .call_contract(
+            CallFunction {
+                contract_address: state.conf.quests.zklend.contract,
+                entry_point_selector: selector!("user_has_debt"),
+                calldata: vec![*addr],
+            },
+            BlockId::Latest,
+        )
+        .await;
+
+    match call_result {
+        Ok(result) => {
+            if result.result[0] == FieldElement::ZERO {
+                get_error("You didn't borrow any liquidity.".to_string())
+            } else {
+                match state.upsert_completed_task(query.addr, task_id).await {
+                    Ok(_) => (StatusCode::OK, Json(json!({"res": true}))).into_response(),
+                    Err(e) => get_error(format!("{}", e)),
+                }
+            }
+        }
+        Err(e) => get_error(format!("{}", e)),
+    }
+}

--- a/src/endpoints/quests/zklend/verify_has_root_domain.rs
+++ b/src/endpoints/quests/zklend/verify_has_root_domain.rs
@@ -1,0 +1,16 @@
+use crate::{
+    common::verify_has_root_domain::execute_has_root_domain,
+    models::{AppState, VerifyQuery},
+};
+use axum::{
+    extract::{Query, State},
+    response::IntoResponse,
+};
+use std::sync::Arc;
+
+pub async fn handler(
+    State(state): State<Arc<AppState>>,
+    Query(query): Query<VerifyQuery>,
+) -> impl IntoResponse {
+    execute_has_root_domain(state, &query.addr, 23).await
+}

--- a/src/endpoints/quests/zklend/verify_twitter_fw.rs
+++ b/src/endpoints/quests/zklend/verify_twitter_fw.rs
@@ -1,0 +1,24 @@
+use std::sync::Arc;
+
+use crate::{
+    models::{AppState, VerifyQuery},
+    utils::{get_error, CompletedTasksTrait},
+};
+use axum::{
+    extract::{Query, State},
+    http::StatusCode,
+    response::IntoResponse,
+    Json,
+};
+use serde_json::json;
+
+pub async fn handler(
+    State(state): State<Arc<AppState>>,
+    Query(query): Query<VerifyQuery>,
+) -> impl IntoResponse {
+    let task_id = 26;
+    match state.upsert_completed_task(query.addr, task_id).await {
+        Ok(_) => (StatusCode::OK, Json(json!({"res": true}))).into_response(),
+        Err(e) => get_error(format!("{}", e)),
+    }
+}

--- a/src/endpoints/quests/zklend/verify_twitter_rt.rs
+++ b/src/endpoints/quests/zklend/verify_twitter_rt.rs
@@ -1,0 +1,24 @@
+use std::sync::Arc;
+
+use crate::{
+    models::{AppState, VerifyQuery},
+    utils::{get_error, CompletedTasksTrait},
+};
+use axum::{
+    extract::{Query, State},
+    http::StatusCode,
+    response::IntoResponse,
+    Json,
+};
+use serde_json::json;
+
+pub async fn handler(
+    State(state): State<Arc<AppState>>,
+    Query(query): Query<VerifyQuery>,
+) -> impl IntoResponse {
+    let task_id = 27;
+    match state.upsert_completed_task(query.addr, task_id).await {
+        Ok(_) => (StatusCode::OK, Json(json!({"res": true}))).into_response(),
+        Err(e) => get_error(format!("{}", e)),
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,6 +92,66 @@ async fn main() {
             get(endpoints::quests::starknetid::verify_socials::handler),
         )
         .route(
+            "/quests/jediswap/verify_has_root_domain",
+            get(endpoints::quests::jediswap::verify_has_root_domain::handler),
+        )
+        .route(
+            "/quests/jediswap/verify_added_liquidity",
+            get(endpoints::quests::jediswap::verify_added_liquidity::handler),
+        )
+        .route(
+            "/quests/jediswap/verify_twitter_fw",
+            get(endpoints::quests::jediswap::verify_twitter_fw::handler),
+        )
+        .route(
+            "/quests/jediswap/verify_twitter_rt",
+            get(endpoints::quests::jediswap::verify_twitter_rt::handler),
+        )
+        .route(
+            "/quests/jediswap/claimable",
+            get(endpoints::quests::jediswap::claimable::handler),
+        )
+        .route(
+            "/quests/zklend/verify_has_root_domain",
+            get(endpoints::quests::zklend::verify_has_root_domain::handler),
+        )
+        .route(
+            "/quests/zklend/verify_borrow",
+            get(endpoints::quests::zklend::verify_borrow::handler),
+        )
+        .route(
+            "/quests/zklend/verify_twitter_fw",
+            get(endpoints::quests::zklend::verify_twitter_fw::handler),
+        )
+        .route(
+            "/quests/zklend/verify_twitter_rt",
+            get(endpoints::quests::zklend::verify_twitter_rt::handler),
+        )
+        .route(
+            "/quests/zklend/claimable",
+            get(endpoints::quests::zklend::claimable::handler),
+        )
+        .route(
+            "/quests/avnu/verify_twitter_fw",
+            get(endpoints::quests::avnu::verify_twitter_fw::handler),
+        )
+        .route(
+            "/quests/avnu/verify_twitter_rt",
+            get(endpoints::quests::avnu::verify_twitter_rt::handler),
+        )
+        .route(
+            "/quests/avnu/discord_fw_callback",
+            get(endpoints::quests::avnu::discord_fw_callback::handler),
+        )
+        .route(
+            "/quests/avnu/verify_swap",
+            get(endpoints::quests::avnu::verify_swap::handler),
+        )
+        .route(
+            "/quests/avnu/claimable",
+            get(endpoints::quests::avnu::claimable::handler),
+        )
+        .route(
             "/quests/tribe/verify_has_domain",
             get(endpoints::quests::tribe::verify_has_domain::handler),
         )

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,8 @@
 use crate::models::{AchievementDocument, AppState, CompletedTasks};
 use async_trait::async_trait;
 use axum::{
-    http::StatusCode,
+    body::Body,
+    http::{Response as HttpResponse, StatusCode, Uri},
     response::{IntoResponse, Response},
 };
 use mongodb::{bson::doc, options::UpdateOptions, results::UpdateResult, Collection};
@@ -15,6 +16,7 @@ use starknet::{
 };
 use std::fmt::Write;
 use std::result::Result;
+use std::str::FromStr;
 
 #[macro_export]
 macro_rules! pub_struct {
@@ -50,6 +52,46 @@ pub async fn get_nft(
 
 pub fn get_error(error: String) -> Response {
     (StatusCode::INTERNAL_SERVER_ERROR, error).into_response()
+}
+
+pub fn get_error_redirect(redirect_uri: String, error: String) -> Response {
+    let err_msg_encoded =
+        percent_encoding::utf8_percent_encode(&error, percent_encoding::NON_ALPHANUMERIC)
+            .to_string();
+    let redirect_url = format!("{}&error_msg={}", redirect_uri, err_msg_encoded);
+    let uri = match Uri::from_str(&redirect_url) {
+        Ok(uri) => uri,
+        Err(_) => return get_error("Failed to create URI from redirect URL".to_string()),
+    };
+
+    let response = match HttpResponse::builder()
+        .status(StatusCode::SEE_OTHER)
+        .header("Location", uri.to_string())
+        .body(Body::from("Redirecting..."))
+    {
+        Ok(response) => response,
+        Err(_) => return get_error("Failed to create HTTP response".to_string()),
+    };
+
+    response.into_response()
+}
+
+pub fn success_redirect(redirect_uri: String) -> Response {
+    let uri = match Uri::from_str(&redirect_uri) {
+        Ok(uri) => uri,
+        Err(_) => return get_error("Failed to create URI from redirect URL".to_string()),
+    };
+
+    let response = match HttpResponse::builder()
+        .status(StatusCode::SEE_OTHER)
+        .header("Location", uri.to_string())
+        .body(Body::from("Redirecting..."))
+    {
+        Ok(response) => response,
+        Err(_) => return get_error("Failed to create HTTP response".to_string()),
+    };
+
+    response.into_response()
 }
 
 #[async_trait]


### PR DESCRIPTION
This PR is related to : https://github.com/starknet-id/starknet.quest/issues/145 

It re adds the endpoint for AVNU, Zklend and Jediswap quests. 

Note that Zklend testnet contract has changed, we need to use this one in the server : `0x05034fde0f3beedf7d943a9e80cd231271c53d8088e840d22bb6c991bdf91b7e`