### PR TITLE
ref: add domain in get_verifier_data

### DIFF
--- a/src/endpoints/quests/starknetid/verify_socials.rs
+++ b/src/endpoints/quests/starknetid/verify_socials.rs
@@ -71,6 +71,7 @@ pub async fn handler(
                 id_res.result[0],
                 short_string!("twitter"),
                 state.conf.starknetid_contracts.verifier_contract,
+                FieldElement::ZERO,
             ],
         )
         .await?;
@@ -83,6 +84,7 @@ pub async fn handler(
                 id_res.result[0],
                 short_string!("discord"),
                 state.conf.starknetid_contracts.verifier_contract,
+                FieldElement::ZERO,
             ],
         )
         .await?;


### PR DESCRIPTION
Adds domains in `get_verifier_data` for `verify_socials` endpoint following an update in the identity contract in preparation of the cairo2 version

Do not merge until the identity contract was updated 