### PR TITLE
feat: add mandatory_domain

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -36,6 +36,7 @@ pub_struct!(Debug, Serialize, Deserialize; QuestDocument {
     disabled: bool,
     expiry: Option<bson::DateTime>,
     expiry_timestamp: Option<String>,
+    mandatory_domain: Option<String>,
 });
 
 pub_struct!(Deserialize; CompletedTasks {


### PR DESCRIPTION
Adds a new field `mandatory_domain` in quests so we can specify for each quest if the user needs to own a root domain, doesn't need a domain, can own a subdomain, etc. 

Part of https://github.com/starknet-id/starknet.quest/issues/252