### PR TITLE
feat: enable/disable achievements

### DIFF
--- a/src/endpoints/achievements/fetch.rs
+++ b/src/endpoints/achievements/fetch.rs
@@ -113,7 +113,7 @@ pub async fn handler(
                 match result {
                     Ok(document) => {
                         if let Ok(achievement) = from_document::<UserAchievements>(document) {
-                            if !achievement.category_disabled.unwrap_or(false) {
+                            if !achievement.category_disabled {
                                 achievements.push(achievement);
                             }
                         }

--- a/src/models.rs
+++ b/src/models.rs
@@ -105,14 +105,20 @@ pub_struct!(Debug, Serialize, Deserialize; AchievementCategoryDocument {
     img_url: String,
 });
 
-pub_struct!(Debug, Serialize, Deserialize; UserAchievements {
+#[derive(Debug, Serialize, Deserialize)]
+pub struct UserAchievements {
     category_name: String,
     category_desc: String,
     category_img_url: String,
     category_type: String,
-    category_disabled: Option<bool>,
+    #[serde(default = "default_category_disabled")]
+    pub category_disabled: bool,
     achievements: Vec<UserAchievement>,
-});
+}
+
+pub fn default_category_disabled() -> bool {
+    false
+}
 
 pub_struct!(Debug, Serialize, Deserialize; UserAchievement {
     id: u32,


### PR DESCRIPTION
Close #104 

I used an `Option<bool>` to avoid having no achievements shown when we pass the feature in production, so if there is not `disabled` specified or if it's set to `false` it would fetch those achievements, wdyt ? 