### PR TITLE
fix: error message naming

### DIFF
--- a/src/endpoints/quests/focustree/engagement/discord_fw_callback.rs
+++ b/src/endpoints/quests/focustree/engagement/discord_fw_callback.rs
@@ -112,7 +112,7 @@ pub async fn handler(
 
     get_error_redirect(
         error_redirect_uri,
-        "You're not part of AVNU's Discord server".to_string(),
+        "You're not part of Focus Tree's Discord server".to_string(),
     )
 }
 


### PR DESCRIPTION
wrong error messaging on focustree discord callback handler. Fixed in this PR