### PR TITLE
feat: add boosted quests query

### DIFF
--- a/src/endpoints/get_boosted_quests.rs
+++ b/src/endpoints/get_boosted_quests.rs
@@ -1,0 +1,40 @@
+use crate::{models::AppState, utils::get_error};
+use axum::{
+    extract::{State},
+    response::IntoResponse,
+    Json,
+};
+
+use futures::TryStreamExt;
+use mongodb::bson::{doc, Document};
+use reqwest::StatusCode;
+use std::sync::Arc;
+
+pub async fn handler(
+    State(state): State<Arc<AppState>>,
+) -> impl IntoResponse {
+    let pipeline = vec![
+        doc! {
+            "$unwind": doc! {
+                "path": "$quests"
+            }
+        },
+        doc! {
+            "$project": doc! {
+                "_id": 0,
+                "id": "$quests"
+            }
+        },
+    ];
+    let tasks_collection = state.db.collection::<Document>("boosts");
+    match tasks_collection.aggregate(pipeline, None).await {
+        Ok(mut cursor) => {
+            let mut quests: Vec<u32> = Vec::new();
+            while let Some(result) = cursor.try_next().await.unwrap() {
+                quests.push(result.get("id").unwrap().as_i32().unwrap() as u32);
+            }
+            (StatusCode::OK, Json(quests)).into_response()
+        }
+        Err(_) => get_error("Error querying boosts".to_string()),
+    }
+}

--- a/src/endpoints/mod.rs
+++ b/src/endpoints/mod.rs
@@ -12,3 +12,4 @@ pub mod has_completed_quest;
 pub mod leaderboard;
 pub mod quest_boost;
 pub mod quests;
+pub mod get_boosted_quests;

--- a/src/endpoints/quests/verify_quiz.rs
+++ b/src/endpoints/quests/verify_quiz.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+    use std::sync::Arc;
 
 use crate::{
     common::verify_quiz::verify_quiz,

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,6 +68,10 @@ async fn main() {
             get(endpoints::get_completed_quests::handler),
         )
         .route(
+            "/get_boosted_quests",
+            get(endpoints::get_boosted_quests::handler),
+        )
+        .route(
             "/has_completed_quests",
             get(endpoints::has_completed_quest::handler),
         )


### PR DESCRIPTION
This PR adds a endpoint which will return the list of quest ids which are boosted. This will be used on FE to show the boosted tag on the homepage to increase CTR on each quest.