### PR TITLE
feat: modify quest model for additional description support

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -23,6 +23,7 @@ pub_struct!(Debug, Serialize, Deserialize; QuestDocument {
     id: u32,
     name: String,
     desc: String,
+    additional_desc: Option<String>,
     issuer: String,
     category: String,
     rewards_endpoint: String,


### PR DESCRIPTION
We need to add a additonal description support for quests. In cases where we need to add a second para to mention anything seperately we can use this