### PR TITLE
feat: add correct data type

### DIFF
--- a/src/endpoints/quest_boost/get_completed_boosts.rs
+++ b/src/endpoints/quest_boost/get_completed_boosts.rs
@@ -89,7 +89,7 @@ pub async fn handler(
         Ok(mut cursor) => {
             let mut boosts: Vec<u32> = Vec::new();
             while let Some(result) = cursor.try_next().await.unwrap() {
-                boosts.push(result.get("id").unwrap().as_i64().unwrap() as u32);
+                boosts.push(result.get("id").unwrap().as_i32().unwrap() as u32);
             }
             (StatusCode::OK, Json(boosts)).into_response()
         }


### PR DESCRIPTION
```
thread 'tokio-runtime-worker' panicked at src/endpoints/quest_boost/get_completed_boosts.rs:93:64:
called `Option::unwrap()` on a `None` value
```
these logs come while fetching this endpoint. This is fixed in this PR