### PR TITLE
feat: add addr field to claim_params endpoint

### DIFF
--- a/src/endpoints/quest_boost/get_claim_params.rs
+++ b/src/endpoints/quest_boost/get_claim_params.rs
@@ -6,23 +6,26 @@ use axum::{
 };
 use std::str::FromStr;
 
-use mongodb::bson::{doc, Document};
+use mongodb::bson::{Bson, doc, Document};
 use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use starknet::core::crypto::ecdsa_sign;
 use starknet::core::{crypto::pedersen_hash, types::FieldElement};
 use std::sync::Arc;
+use crate::utils::to_hex;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct GetClaimBoostQuery {
     boost_id: u32,
+    addr: FieldElement,
 }
 
 pub async fn handler(
     State(state): State<Arc<AppState>>,
     Query(query): Query<GetClaimBoostQuery>,
 ) -> impl IntoResponse {
+    let address = to_hex(query.addr);
     let boost_id = query.boost_id;
     let collection = state.db.collection::<Document>("boosts");
     let res = collection.find_one(doc! {"id":boost_id}, None).await.unwrap();
@@ -36,7 +39,14 @@ pub async fn handler(
     let num_of_winners = boost.get("num_of_winners").unwrap().as_i32().unwrap();
     let amount = boost.get("amount").unwrap().as_i32().unwrap() as u32 / num_of_winners as u32;
     let token = boost.get("token").unwrap().as_str().unwrap();
-    let address = boost.get("winner").unwrap().as_str().unwrap();
+
+    let winner_list = boost.get("winner").unwrap().as_array().unwrap();
+    let bson_value: Bson = Bson::String(address.clone());
+
+    // if the user is not in the winner list
+    if !winner_list.contains(&bson_value) {
+        return get_error(format!("User {} is not in the winner list", address.clone()));
+    }
 
     let hashed = pedersen_hash(
         &FieldElement::from(boost_id),
@@ -46,7 +56,7 @@ pub async fn handler(
                 &FieldElement::from(0 as u32),
                 &pedersen_hash(
                     &FieldElement::from_str(token).unwrap(),
-                    &FieldElement::from_str(address).unwrap(),
+                    &FieldElement::from_str(&*address).unwrap(),
                 ),
             ),
         ),


### PR DESCRIPTION
Adding a `addr` field to the `get_claim_params` endpoint since it is important to verify if the user which is asking for this value; has his address in the winner field array.