### PR TITLE
feat: removed claimed status from boost query

### DIFF
--- a/src/endpoints/quest_boost/get_boost.rs
+++ b/src/endpoints/quest_boost/get_boost.rs
@@ -12,7 +12,6 @@ use futures::StreamExt;
 use mongodb::bson::doc;
 use serde::Deserialize;
 use std::sync::Arc;
-
 #[derive(Deserialize)]
 pub struct GetQuestsQuery {
     id: u32,
@@ -29,40 +28,6 @@ pub async fn handler(
             "$match": {
                 "id": query.id
             }
-        },
-        doc! {
-            "$lookup": doc! {
-                "from": "boost_claims",
-                "localField": "id",
-                "foreignField": "id",
-                "as": "claim_detail"
-            }
-        },
-        doc! {
-        "$addFields": doc! {
-            "claimed": doc! {
-                "$anyElementTrue": doc! {
-                    "$map": doc! {
-                        "input": "$claim_detail",
-                        "as": "claimDetail",
-                        "in": doc! {
-                        "$eq": [
-                            doc! {
-                                "$ifNull": [
-                                    "$$claimDetail._cursor.to",
-                                    null
-                                ]
-                            },
-                            null
-                        ]
-                        }
-                    }
-                }
-            }
-        },
-        },
-        doc! {
-            "$unset": "claim_detail"
         },
         doc! {
             "$project":{

--- a/src/endpoints/quest_boost/get_pending_claims.rs
+++ b/src/endpoints/quest_boost/get_pending_claims.rs
@@ -33,8 +33,13 @@ pub async fn handler(
     let collection = state.db.collection::<QuestDocument>("boosts");
     let pipeline = [
         doc! {
-            "$match": {
-                "winner":address
+            "$unwind": doc! {
+                "path": "$winner"
+            }
+        },
+        doc! {
+            "$match": doc! {
+                "winner": address,
             }
         },
         doc! {
@@ -56,7 +61,10 @@ pub async fn handler(
                                         ]
                                     },
                                     doc! {
-                                        "$in": ["$$localWinner","$winner"],
+                                        "$eq": [
+                                            "$winner",
+                                            "$$localWinner"
+                                        ]
                                     },
                                     doc! {
                                         "$eq": [
@@ -88,7 +96,7 @@ pub async fn handler(
             "$project": doc! {
                 "_id": 0,
                 "boost_claims": 0,
-                "hidden":0
+                "hidden": 0
             }
         },
     ];


### PR DESCRIPTION
This PR makes the following changes - 
- removes the `claimed` field from the `get_boost` query which returns the boost information based on `id`. Since there are mulltiple winners, we don't have a `claimed` value as such since there is no single winner. 
- I also fix the `pending_claims` query to support multiple winners. Currrently the query didn't support querying the correct pending claims by a user.

Earlier approach - 
- We used to match the winner from the boost but the assumption was that there is only one winner. So we used to match the boost winner with the claims which match in the boost_claims collection.

but now - the winner per boost is multiple, so the searching query doesn't function the same way.
To tackle this, i unwind in the first step to make it similar to how the query used to run and then check for equality in the following steps on the following fields - claim boost `id` to the matching boost id  , `winner` (the winner address) to the claiming winner address and `_cursor.to`  to `null`.

the flow for the product looks something like this -

1) User comes on the claim page
2) We fetch the boost information (check if user is winner)
3) We check in localstorage if boost is claimed(we save in localstorage in FE if the user has already claimed/opened the reward)
4)if nothing on localstorage , then we check from pending claims(this takes data from indexer and finds if user has claimed anything from contract for this boost id)
3) Check from the information above
 a) if winner -> show a disabled/enabled claim button depending on steps 3 and 4
 b) if not winner -> show the `better luck next time` image
 
 The checks we make for enabled and disabled claim button -
 
 Enabled (these both are AND conditions)
 - Step 3 -> there is nothing in localstorage of the user which shows that he has not claimed before
 - Step 4 -> there is a pending claim with a boost id and it matches to the boost id which he/she is trying to claim
 
 Disabled (these both are OR conditions)
 - Step 3 -> local storage shows they have done this claim already 
-  Step 4 -> there are no pending claims from the indexer data