### PR TITLE
fix: expired quests are not shown as expired on boost page

### DIFF
--- a/src/endpoints/quest_boost/get_quests.rs
+++ b/src/endpoints/quest_boost/get_quests.rs
@@ -81,7 +81,20 @@ pub async fn handler(
                         "input": "$quest_list",
                         "as": "item",
                         "in": {
-                            "$mergeObjects": ["$$item"],
+                            "$mergeObjects": ["$$item", doc! {
+                                "expired": {
+                                    "$cond": [
+                                        {
+                                            "$and": [
+                                                { "$gte": ["$$item.expiry", 0] },
+                                                { "$lt": ["$$item.expiry", "$$NOW"] },
+                                            ]
+                                        },
+                                        true,
+                                        false
+                                    ]
+                                }
+                            }],
                         },
                     }
                 }


### PR DESCRIPTION
https://github.com/starknet-id/starknet.quest/issues/488