### PR TITLE
feat: add quest completion activity

### DIFF
--- a/src/endpoints/analytics/get_quest_activity.rs
+++ b/src/endpoints/analytics/get_quest_activity.rs
@@ -1,4 +1,4 @@
-use crate::models::{QuestTaskDocument};
+use crate::models::QuestTaskDocument;
 use crate::{models::AppState, utils::get_error};
 use axum::{
     extract::{Query, State},
@@ -8,78 +8,134 @@ use axum::{
 use axum_auto_routes::route;
 use futures::StreamExt;
 use mongodb::bson::doc;
-use std::sync::Arc;
 use serde::Deserialize;
+use std::sync::Arc;
 
 #[derive(Deserialize)]
 pub struct GetQuestsQuery {
     id: u32,
 }
 
-
-#[route(get, "/analytics/get_quest_activity", crate::endpoints::analytics::get_quest_activity)]
-pub async fn handler(State(state): State<Arc<AppState>>,
-                     Query(query): Query<GetQuestsQuery>,
+#[route(
+    get,
+    "/analytics/get_quest_activity",
+    crate::endpoints::analytics::get_quest_activity
+)]
+pub async fn handler(
+    State(state): State<Arc<AppState>>,
+    Query(query): Query<GetQuestsQuery>,
 ) -> impl IntoResponse {
     let quest_id = query.id;
     let day_wise_distribution = vec![
         doc! {
-        "$match": doc! {
-            "quest_id": quest_id
-        }
-    },
-        doc! {
-        "$group": doc! {
-            "_id": null,
-            "ids": doc! {
-                "$push": "$id"
+            "$match": doc! {
+                "quest_id": quest_id
             }
-        }
-    },
+        },
         doc! {
-        "$lookup": doc! {
-            "from": "completed_tasks",
-            "localField": "ids",
-            "foreignField": "task_id",
-            "as": "matching_documents"
-        }
-    },
-        doc! {
-        "$unwind": "$matching_documents"
-    },
-        doc! {
-        "$replaceRoot": doc! {
-            "newRoot": "$matching_documents"
-        }
-    },
-        doc! {
-        "$addFields": doc! {
-            "createdDate": doc! {
-                "$toDate": "$timestamp"
-            }
-        }
-    },
-        doc! {
-        "$group": doc! {
-            "_id": doc! {
-                "$dateToString": doc! {
-                    "format": "%Y-%m-%d %d",
-                    "date": "$createdDate"
+            "$group": doc! {
+                "_id": null,
+                "ids": doc! {
+                    "$push": "$id"
                 }
-            },
-            "participants": doc! {
-                "$sum": 1
             }
-        }
-    },
+        },
         doc! {
-        "$sort": doc! {
-            "_id": 1
-        }
-    },
+            "$lookup": doc! {
+                "from": "completed_tasks",
+                "localField": "ids",
+                "foreignField": "task_id",
+                "as": "matching_documents"
+            }
+        },
+        doc! {
+            "$unwind": "$matching_documents"
+        },
+        doc! {
+            "$replaceRoot": doc! {
+                "newRoot": doc! {
+                    "$mergeObjects": [
+                        "$$ROOT",
+                        "$matching_documents"
+                    ]
+                }
+            }
+        },
+        doc! {
+            "$group": doc! {
+                "_id": doc! {
+                    "_id": "$address",
+                    "ids": "$ids"
+                },
+                "maxTimestamp": doc! {
+                    "$max": "$timestamp"
+                },
+                "tasks": doc! {
+                    "$addToSet": "$task_id"
+                },
+                "count": doc! {
+                    "$sum": 1
+                }
+            }
+        },
+        doc! {
+            "$addFields": doc! {
+                "createdDate": doc! {
+                    "$toDate": "$maxTimestamp"
+                }
+            }
+        },
+        doc! {
+            "$match": doc! {
+                "$expr": doc! {
+                    "$and": [
+                        doc! {
+                            "$eq": [
+                                doc! {
+                                    "$size": "$tasks"
+                                },
+                                doc! {
+                                    "$size": "$_id.ids"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        },
+        doc! {
+            "$group": doc! {
+                "_id": doc! {
+                    "$dateToString": doc! {
+                        "format": "%Y-%m-%d %d",
+                        "date": "$createdDate"
+                    }
+                },
+                "count": doc! {
+                    "$sum": 1
+                }
+            }
+        },
+        doc! {
+            "$sort": doc! {
+                "_id": 1
+            }
+        },
+        doc! {
+            "$project": doc! {
+                "_id": 0,
+                "date": "$_id",
+                "participants": "$count"
+            }
+        },
     ];
 
-    match state.db.collection::<QuestTaskDocument>("tasks").aggregate(day_wise_distribution, None).await {
+    match state
+        .db
+        .collection::<QuestTaskDocument>("tasks")
+        .aggregate(day_wise_distribution, None)
+        .await
+    {
         Ok(mut cursor) => {
             let mut day_wise_distribution = Vec::new();
             while let Some(result) = cursor.next().await {


### PR DESCRIPTION
In the previous PR for analytics i calculate the tasks completed per day and what we actually wanted to do was quests completed per day. 

This is the original PR for ref - https://github.com/starknet-id/api.starknet.quest/pull/195

in the PR's description I make this endpoint such that it returns completion of tasks per day. On going through the brief again i see that it was actually quests completion per day. 

