### PR TITLE
feat: add current-time check

### DIFF
--- a/src/endpoints/get_quest.rs
+++ b/src/endpoints/get_quest.rs
@@ -25,6 +25,7 @@ pub async fn handler(
     Query(query): Query<GetQuestsQuery>,
 ) -> impl IntoResponse {
     let collection = state.db.collection::<QuestDocument>("quests");
+    let current_time = chrono::Utc::now().timestamp_millis();
 
     let pipeline = [
         doc! {
@@ -48,7 +49,7 @@ pub async fn handler(
                                 doc! {
                                     "$lt": [
                                         "$expiry",
-                                        "$$NOW"
+                                        current_time
                                     ]
                                 }
                             ]

--- a/src/endpoints/get_quests.rs
+++ b/src/endpoints/get_quests.rs
@@ -49,7 +49,7 @@ pub async fn handler(State(state): State<Arc<AppState>>) -> impl IntoResponse {
                                 doc! {
                                     "$lt": [
                                         "$expiry",
-                                        "$$NOW"
+                                    current_time
                                     ]
                                 }
                             ]

--- a/src/endpoints/get_trending_quests.rs
+++ b/src/endpoints/get_trending_quests.rs
@@ -49,7 +49,7 @@ pub async fn handler(
                         {
                             "$and": [
                                 { "$gte": ["$expiry", 0] },
-                                { "$lt": ["$expiry", "$$NOW"] },
+                                { "$lt": ["$expiry", current_time] },
                             ]
                         },
                         true,

--- a/src/endpoints/quest_boost/get_quests.rs
+++ b/src/endpoints/quest_boost/get_quests.rs
@@ -24,6 +24,8 @@ pub async fn handler(
     Query(query): Query<GetQuestForBoostQuery>,
 ) -> impl IntoResponse {
     let boost_id = query.boost_id;
+    let current_time = chrono::Utc::now().timestamp_millis();
+
     let pipeline = vec![
         doc! {
             "$match": doc! {
@@ -87,7 +89,7 @@ pub async fn handler(
                                         {
                                             "$and": [
                                                 { "$gte": ["$$item.expiry", 0] },
-                                                { "$lt": ["$$item.expiry", "$$NOW"] },
+                                                { "$lt": ["$$item.expiry", current_time] },
                                             ]
                                         },
                                         true,


### PR DESCRIPTION
The $$NOW operator uses ISO Timestamp whereas the new implementation in this PR will include the epoch timestamp