### PR TITLE
fixes issue #244: Removed duplicate entries and replaces 0xXXX with valid random hex codes

### DIFF
--- a/config.template.toml
+++ b/config.template.toml
@@ -22,13 +22,13 @@ api_endpoint="XXXXXXXXXXXX"
 api_endpoint="XXXXXXXXXXXX"
 
 [nft_contract]
-address = "0xXXXXXXXXXXXX"
+address = "0xFFFFFFFFFFFF"
 private_key = "1"
 
 [starknetid_contracts]
-naming_contract = "0xXXXXXXXXXXXX"
-verifier_contracts = [ "0xXXXXXXXXXXXX" ]
-identity_contract = "0xXXXXXXXXXXXX"
+naming_contract = "0xFFFFFFFFFFFF"
+verifier_contracts = [ "0xFFFFFFFFFFFF" ]
+identity_contract = "0xFFFFFFFFFFFF"
 
 [rango]
 api_endpoint="XXXXXXXXXXXXXXXXX"
@@ -37,51 +37,41 @@ api_key="XXXXXXXXXXXXXXXXX"
 [quests]
 utils_contract = "0x012"
 [quests.sithswap]
-utils_contract = "0xXXXXXXXXXXXX"
-pairs = ["0xXXXXXXXXXXXX"]
+utils_contract = "0xFFFFFFFFFFFF"
+pairs = ["0xFFFFFFFFFFFF"]
 [quests.jediswap]
-utils_contract = "0xXXXXXXXXXXXX"
-pairs = ["0xXXXXXXXXXXXX"]
+utils_contract = "0xFFFFFFFFFFFF"
+pairs = ["0xFFFFFFFFFFFF"]
 [quests.carbonable]
 contract = "0x014c6533fec6fd168189b49150907db533e8be3a2e69b0657ae4ec6459a94668"
 [quests.hashstack]
 contract = "0x0"
 token_address = "0x0"
 [quests.zklend]
-contract = "0xXXXXXXXXXXXX"
-utils_contract = "0xXXXXXXXXXXXX"
-pairs = ["0xXXXXXXXXXXXX"]
+contract = "0xFFFFFFFFFFFF"
+utils_contract = "0xFFFFFFFFFFFF"
+pairs = ["0xFFFFFFFFFFFF"]
 [quests.ekubo]
-contract = "0xXXXXXXXXXXXX"
+contract = "0xFFFFFFFFFFFF"
 [quests.myswap]
-contract = "0xXXXXXXXXXXXX"
+contract = "0xFFFFFFFFFFFF"
 [quests.braavos]
 api_key_user = "xxxxxx"
 api_key_claimed_mission = "xxxxxx"
 [quests.element]
 api_key = "xxxxxx"
 [quests.nostra]
-utils_contract = "0xXXXXXXXXXXXX"
-pairs = ["0xXXXXXXXXXXXX"]
-staking_contract="0xXXXXXXXXXXXX"
+utils_contract = "0xFFFFFFFFFFFF"
+pairs = ["0xFFFFFFFFFFFF"]
+staking_contract="0xFFFFFFFFFFFF"
 [quests.haiko]
 api_endpoint = "xxxxxx"
 [quests.nimbora]
-contract = "0xXXXXXXXXXXXX"
+contract = "0xFFFFFFFFFFFF"
 [quests.bountive]
-contract = "0xXXXXXXXXXXXX"
+contract = "0xFFFFFFFFFFFF"
 [quests.sithswap_2]
 api_endpoint = "xxxxxxx"
-
-[rhino]
-api_endpoint = "xxxxx"
-
-[rango]
-api_endpoint = "xxxxx"
-api_key = "xxxxx"
-
-[pyramid]
-api_endpoint= "xxxxx"
 
 [twitter]
 oauth2_clientid = "xxxxxx"

--- a/config.template.toml
+++ b/config.template.toml
@@ -99,7 +99,7 @@ contract = "0x01b22f7a9d18754c994ae0ee9adb4628d414232e3ebd748c386ac286f86c3066"
 contract = "0x0541b5dd5fae206ceccaf4eeb0642e4c04d456c5bc296eab047c9414bdad4f09"
 
 [quest_boost]
-private_key = "xxxxxx"
+private_key = "0xFFFFFFFFFFFF"
 update_interval = 600
 
 [quizzes]


### PR DESCRIPTION
This Pull Request is for resolving issue #244. There are no more issues regarding the invalid hex codes now. Here's the checklist for the PR:

- [x] Fix issues such as the "[rhino]" or "[pyramid]" categories which are present twice
- [x] Replace template Hex values such as "0xXXXXXXXXXXXX" which are not numbers as it's only composed of "XXX..." by random Hex values such as "0xFFFFF"
- [x] Check there are no other parsing errors

This PR has been done as part of OnlyDust's ODHack 7.0.