### PR TITLE
Parse string utils function #264

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -42,7 +42,6 @@ macro_rules! pub_struct {
         }
     }
 }
-   
 
 pub async fn get_nft(
     quest_id: u32,
@@ -826,4 +825,18 @@ impl Clone for Box<dyn WithState> {
     fn clone(&self) -> Box<dyn WithState> {
         self.box_clone()
     }
+}
+
+pub fn parse_string(input: &str, address: FieldElement) -> String {
+    let mut result = input.to_string();
+
+    if input.contains("{addr_hex}") {
+        result = result.replace("{addr_hex}", to_hex(address).as_str());
+    }
+
+    if input.contains("{addr_dec}") {
+        result = result.replace("{addr_dec}", address.to_string().as_str());
+    }
+
+    result
 }


### PR DESCRIPTION
 The new function **parse_string** replaces placeholders in a string with a given address in hexadecimal and decimal formats.

**Input:** A string (input) with placeholders {addr_hex} and {addr_dec} and a FieldElement (address).
**Output:** A new string with placeholders replaced by the address in hex and decimal formats.
**Usage:** 
`let result = parse_string("Your address: {addr_hex}, {addr_dec}.", address);`