### PR TITLE
Fix : #287 create_boost.rs

### DIFF
--- a/src/endpoints/admin/quest_boost/create_boost.rs
+++ b/src/endpoints/admin/quest_boost/create_boost.rs
@@ -35,7 +35,7 @@ pub async fn handler(
 ) -> impl IntoResponse {
     let collection = state.db.collection::<BoostTable>("boosts");
     let quests_collection = state.db.collection::<QuestDocument>("quests");
-    let insert_collection = state.db.collection::<QuestTaskDocument>("quests");
+    let insert_collection = state.db.collection::<QuestTaskDocument>("tasks");
 
     let res = verify_quest_auth(sub, &quests_collection, &(body.quest_id as i64)).await;
     if !res {


### PR DESCRIPTION
In src/endpoints/admin/quest_boost/create_boost.rs, line 38,  I remove "quests "  and replace with "tasks" . (Because we already get the quests collection on the upper line).