### PR TITLE
Fix question ids

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -55,6 +55,7 @@ async fn main() {
 
     let shared_state = Arc::new(models::AppState {
         last_task_id: sync::Mutex::new(0),
+        last_question_id: sync::Mutex::new(0),
         logger: logger.clone(),
         conf: conf.clone(),
         provider: JsonRpcClient::new(HttpTransport::new(

--- a/src/models.rs
+++ b/src/models.rs
@@ -12,6 +12,7 @@ use tokio::sync::Mutex;
 
 pub_struct!(;AppState {
     last_task_id: Mutex<i64>,
+    last_question_id: Mutex<i64>,
     conf: Config,
     provider: JsonRpcClient<HttpTransport>,
     db: Database,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,6 @@
 use crate::logger::Logger;
 use crate::models::{
-    AchievementDocument, AppState, BoostTable, CompletedTasks, LeaderboardTable, QuestDocument, QuestTaskDocument, RewardSource, UserExperience
+    AchievementDocument, AppState, BoostTable, CompletedTasks, LeaderboardTable, QuestDocument, QuestTaskDocument, QuizQuestionDocument, RewardSource, UserExperience
 };
 use async_trait::async_trait;
 use axum::{
@@ -881,6 +881,27 @@ pub async fn get_next_task_id(
         return std::cmp::max(db_last_id as i32, (last_task_id).try_into().unwrap()) + 1;
     } else {
         return (last_task_id as i32) + 1;
+    }
+}
+
+pub async fn get_next_question_id(
+    question_collection: &Collection<QuizQuestionDocument>,
+    last_question_id: i64,
+) -> i64 {
+    let last_id_filter = doc! {};
+    let options = FindOneOptions::builder().sort(doc! {"id": -1}).build();
+
+    let last_doc = question_collection
+        .find_one(last_id_filter, options)
+        .await
+        .unwrap();
+
+    if let Some(doc) = last_doc {
+        let db_last_id = doc.id;
+
+        return std::cmp::max(db_last_id, last_question_id) + 1;
+    } else {
+        return last_question_id + 1;
     }
 }
 


### PR DESCRIPTION
This PR fixes the next question id problem by using a mutex lock pattern.

Note that the get_next_task_id is used elsewhere in the codebase and is likely to cause the same kind of issues.
Maybe a generic get_next_collection_id should be created to ensure uniqueness of every collection ids.

Fix #292 