### PR TITLE
Fix: Implement get_boost_winners admin route

### DIFF
--- a/src/endpoints/admin/quest_boost/get_boost_winners.rs
+++ b/src/endpoints/admin/quest_boost/get_boost_winners.rs
@@ -20,7 +20,7 @@ pub struct GetBoostWinnersParams {
 #[route(get, "/admin/boosts/get_boost_winners", auth_middleware)]
 pub async fn get_boost_winners_handler(
     State(state): State<Arc<AppState>>,
-    Extension(_sub): Extension<String>, // Assuming admin authentication is handled
+    Extension(_sub): Extension<String>,
     Query(params): Query<GetBoostWinnersParams>,
 ) -> impl IntoResponse {
     let collection = state.db.collection::<BoostTable>("boosts");

--- a/src/endpoints/admin/quest_boost/get_boost_winners.rs
+++ b/src/endpoints/admin/quest_boost/get_boost_winners.rs
@@ -1,0 +1,37 @@
+use crate::middleware::auth::auth_middleware;
+use crate::models::{AppState, BoostTable};
+use crate::utils::get_error;
+use axum::{
+    extract::{Query, State, Extension},
+    response::IntoResponse,
+    Json,
+};
+use axum_auto_routes::route;
+use mongodb::bson::doc;
+use serde::Deserialize;
+use std::sync::Arc;
+use serde_json::json;
+
+#[derive(Deserialize)]
+pub struct GetBoostWinnersParams {
+    boost_id: i64,
+}
+
+#[route(get, "/admin/boosts/get_boost_winners", auth_middleware)]
+pub async fn get_boost_winners_handler(
+    State(state): State<Arc<AppState>>,
+    Extension(_sub): Extension<String>, // Assuming admin authentication is handled
+    Query(params): Query<GetBoostWinnersParams>,
+) -> impl IntoResponse {
+    let collection = state.db.collection::<BoostTable>("boosts");
+
+    let filter = doc! { "id": params.boost_id };
+
+    match collection.find_one(filter, None).await {
+        Ok(Some(boost_doc)) => {
+            Json(json!({ "winners": boost_doc.winner })).into_response()
+        },
+        Ok(None) => get_error(format!("Boost with id {} not found", params.boost_id)),
+        Err(e) => get_error(format!("Error fetching boost winners: {}", e)),
+    }
+}

--- a/src/endpoints/admin/quest_boost/mod.rs
+++ b/src/endpoints/admin/quest_boost/mod.rs
@@ -1,3 +1,6 @@
 pub mod create_boost;
+pub mod get_boost_winners;
 pub mod get_quest_users;
 pub mod update_boost;
+
+pub use get_boost_winners::get_boost_winners_handler;

--- a/src/endpoints/admin/quest_boost/mod.rs
+++ b/src/endpoints/admin/quest_boost/mod.rs
@@ -2,5 +2,3 @@ pub mod create_boost;
 pub mod get_boost_winners;
 pub mod get_quest_users;
 pub mod update_boost;
-
-pub use get_boost_winners::get_boost_winners_handler;


### PR DESCRIPTION
Implements new GET endpoint `/admin/boosts/get_boost_winners` to retrieve winners for a specific boost ID. Protected by admin authentication middleware.

Close #324