### PR TITLE
Fix 366

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -489,7 +489,7 @@ pub struct VesuData {
 pub struct VesuDistributorData {
     pub distributed_amount: String,
     pub claimed_amount: String,
-    pub call_data: VesuCallData,
+    pub call_data: Option<VesuCallData>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/src/tests/endpoints.rs
+++ b/src/tests/endpoints.rs
@@ -26,4 +26,22 @@ pub mod tests {
         let response = client.get(endpoint).send().await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
     }
+
+    #[tokio::test]
+    pub async fn test_ok_with_address_without_callback() {
+        let address = "0x05f1f8de723d8117daa26ec24320d0eacabc53a3d642acb0880846486e73283a";
+        let endpoint = format!("http://0.0.0.0:8080/defi/rewards?addr={}", address);
+        let client = reqwest::Client::new();
+        let response = client.get(endpoint).send().await.unwrap();
+
+        // Should return OK status even when no rewards are available
+        assert_eq!(response.status(), StatusCode::OK);
+
+        // Response should be an empty array
+        let rewards: Vec<serde_json::Value> = response.json().await.unwrap();
+        assert!(
+            rewards.is_empty(),
+            "Expected empty rewards array for address without callback data"
+        );
+    }
 }


### PR DESCRIPTION
close: #366 
we made versu Call data optional then return an empty response if there is no call data. we also return an empty vector in case of an error. is this a desirable trait?